### PR TITLE
fix: correct URL parameter handling in fetchLibraryDocumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ No tab-switching, no hallucinated APIs that don't exist, no outdated code genera
 
 Go to: `Settings` -> `Cursor Settings` -> `MCP` -> `Add new global MCP server`
 
-Paste this into your Cursor `~/.cursor/mcp.json` file. See [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol) for more info. 
+Paste this into your Cursor `~/.cursor/mcp.json` file. See [Cursor MCP docs](https://docs.cursor.com/context/model-context-protocol) for more info.
 
 ```json
 {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -47,9 +47,9 @@ export async function fetchLibraryDocumentation(
       folders = foldersParam;
     }
     const contextURL = new URL(`${CONTEXT7_BASE_URL}/${basePath}/llms.txt`);
-    if (folders) contextURL.set("folders", folders);
-    if (tokens) contextURL.set("tokens", tokens);
-    if (topic) contextURL.set("topic", topic);
+    if (folders) contextURL.searchParams.set("folders", folders);
+    if (tokens) contextURL.searchParams.set("tokens", tokens.toString());
+    if (topic) contextURL.searchParams.set("topic", topic);
 
     const response = await fetch(contextURL);
     if (!response.ok) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -47,9 +47,9 @@ export async function fetchLibraryDocumentation(
       folders = foldersParam;
     }
     const contextURL = new URL(`${CONTEXT7_BASE_URL}/${basePath}/llms.txt`);
-    if (folders) contextURL.set('folders', folders)
-    if (tokens) contextURL.set('tokens', tokens)
-    if (topic) contextURL.set('topic', topic)
+    if (folders) contextURL.set("folders", folders);
+    if (tokens) contextURL.set("tokens", tokens);
+    if (topic) contextURL.set("topic", topic);
 
     const response = await fetch(contextURL);
     if (!response.ok) {


### PR DESCRIPTION
This PR fixes an issue with URL parameter handling in the `fetchLibraryDocumentation` function. The changes:

1. Replace incorrect `contextURL.set()` with `contextURL.searchParams.set()` for proper URL parameter handling
2. Convert tokens to string when setting as URL parameter
3. Use consistent double quotes for string literals

